### PR TITLE
fix segfault with netbsd-curses

### DIFF
--- a/mpv_curses.c
+++ b/mpv_curses.c
@@ -783,7 +783,7 @@ static mpdm_t ncursesw_drv_startup(mpdm_t a)
 {
     register_functions();
 
-    initscr();
+    cw = initscr();
     start_color();
 
 #ifdef NCURSES_MOUSE_VERSION
@@ -813,8 +813,6 @@ static mpdm_t ncursesw_drv_startup(mpdm_t a)
 #ifndef NCURSES_VERSION
     signal(SIGWINCH, nc_sigwinch);
 #endif
-
-    cw = stdscr;
 
     return NULL;
 }


### PR DESCRIPTION
when compiled with netbsd-curses[0], build_colors() segfaults when
calling an ncurses function while cw is NULL. apparently ncurses behavior
differs here in that it assumes window == NULL == stdscr.

[0] https://github.com/sabotage-linux/netbsd-curses/