### PR TITLE
Add cut line behavior and missing shortcut keys

### DIFF
--- a/doc/mp_keycodes.txt
+++ b/doc/mp_keycodes.txt
@@ -36,6 +36,8 @@ Table with Minimum Profit's keycodes and their default assigned actions.
  +---------------------+------------------------+
  |              ctrl-d |           section_list |
  +---------------------+------------------------+
+ |              ctrl-e |          document_list |
+ +---------------------+------------------------+
  |            ctrl-end |               move_eof |
  +---------------------+------------------------+
  |          ctrl-enter |      open_under_cursor |
@@ -85,6 +87,8 @@ Table with Minimum Profit's keycodes and their default assigned actions.
  |              ctrl-x |               cut_mark |
  +---------------------+------------------------+
  |              ctrl-y |            delete_line |
+ +---------------------+------------------------+
+ |              ctrl-k |               cut_line |
  +---------------------+------------------------+
  |              ctrl-z |                   undo |
  +---------------------+------------------------+

--- a/mp_clipboard.mpsl
+++ b/mp_clipboard.mpsl
@@ -70,7 +70,8 @@ mp_doc.actions ~= {
         }
 
         return d;
-    }
+    },
+    cut_line: sub (d) { d->busy(1)->store_undo()->cut_line()->busy(0); }
 };
 
 
@@ -380,6 +381,34 @@ sub mp_doc.cut_lines_with_string(doc, str)
 
     mp.clipboard = r;
     mp_drv.clip_to_sys();
+
+    return doc;
+}
+
+/**
+ * mp_doc.cut_line - Cut current line to clipboard
+ * @doc: the document
+ * 
+ * Cut the current line to the clipboard. 
+ */
+sub mp_doc.cut_line(doc)
+{
+    if (doc.txt.mark) {
+        doc->cut();
+        doc->unmark();
+
+        return doc;
+    }
+
+    doc.txt.x = 0;
+    doc->mark();
+    if (doc.txt.y < size(doc.txt.lines) - 1)
+        doc.txt.y++;
+    else 
+        doc->move_eol();
+    doc->mark();
+    doc->cut();
+    doc->unmark();
 
     return doc;
 }

--- a/mp_clipboard.mpsl
+++ b/mp_clipboard.mpsl
@@ -29,7 +29,9 @@
 
 mp_doc.actions ~= {
     unmark:             sub (d) { d->unmark(); },
+    mark_tag:           sub (d) { d->start_selection(0); },
     mark:               sub (d) { d->mark(); },
+    mark_tag_vertical:  sub (d) { d->start_selection(1); },
     mark_vertical:      sub (d) { d->mark_vertical(); },
     copy_mark:          sub (d) { d->busy(1)->copy()->unmark()->busy(0); },
     paste_mark:         sub (d) { d->busy(1)->store_undo()->paste()->busy(0); },
@@ -79,8 +81,8 @@ mp_doc.actions ~= {
 
 mp_doc.keycodes ~= {
     "f8" =>         "unmark",
-    "f9" =>         "mark",
-    "ctrl-b" =>     "mark_vertical",
+    "f9" =>         "mark_tag",
+    "ctrl-b" =>     "mark_tag_vertical",
     "ctrl-c" =>     "copy_mark",
     "ctrl-v" =>     "paste_mark",
     "ctrl-x" =>     "cut_mark",
@@ -91,8 +93,10 @@ mp_doc.keycodes ~= {
 
 mp.actdesc ~= {
     unmark:                   LL("Unmark block"),
-    mark:                     LL("Mark beginning/end of block"),
-    mark_vertical:            LL("Mark vertical block"),
+    mark_tag:                 LL("Mark beginning/end of block"),
+    mark:                     LL("Mark selection block"),
+    mark_tag_vertical:        LL("Mark vertical block"),
+    mark_vertical:            LL("Mark vertical selection block"),
     copy_mark:                LL("Copy block"),
     paste_mark:               LL("Paste block"),
     cut_mark:                 LL("Cut block"),
@@ -110,6 +114,23 @@ sub mp_doc.unmark(doc)
 {
     /* just destroy the mark */
     doc.txt.mark = NULL;
+    doc.txt.selecting_mode = NULL;
+
+    return doc;
+}
+
+sub mp_doc.start_selection(doc, vertical)
+/* start a toggle selection mode */
+{
+    local txt = doc.txt;
+
+    /* If there is no selection yet with keys */
+    if (txt.selecting_mode == NULL) {
+        /* Make one */
+        txt.selecting_mode = { trigger: vertical };
+    }
+    doc->mark();
+    if (vertical == 1) doc.txt.mark.vertical = 1;
 
     return doc;
 }

--- a/mp_edit.mpsl
+++ b/mp_edit.mpsl
@@ -262,6 +262,7 @@ mp_doc.keycodes['backspace']        = "delete_left";
 mp_doc.keycodes['ctrl-i']           = "tab";
 mp_doc.keycodes['ctrl-m']           = "enter";
 mp_doc.keycodes['ctrl-y']           = "delete_line";
+mp_doc.keycodes['ctrl-k']           = "cut_line";
 mp_doc.keycodes['alt-cursor-right'] = "indent_block";
 mp_doc.keycodes['alt-cursor-left']  = "unindent_block";
 mp_doc.keycodes['ctrl-z']           = "undo";

--- a/mp_edit.mpsl
+++ b/mp_edit.mpsl
@@ -39,9 +39,11 @@ mp_doc.actions['insert_line'] = sub (d) {
 
 mp_doc.actions['delete_line']       = sub (d) { d->store_undo()->delete_line(); };
 mp_doc.actions['insert_space']      = sub (d) { d->store_undo()->insert_space(); };
-mp_doc.actions['insert_tab']        = sub (d) { d->store_undo()->insert_tab(); };
-mp_doc.actions['insert_real_tab']   = sub (d) { d->store_undo()->insert("\t"); };
+mp_doc.actions['insert_tab']        = sub (d) { d->store_undo()->indent_block(1); };
+mp_doc.actions['insert_real_tab']   = sub (d) { d->store_undo()->unindent_block(1); };
 mp_doc.actions['delete']            = sub (d) { d->store_undo()->delete_char(); };
+mp_doc.actions['indent_block']      = sub (d) { d->store_undo()->indent_block(0); };
+mp_doc.actions['unindent_block']    = sub (d) { d->store_undo()->unindent_block(0); };
 
 mp_doc.actions['delete_left']	= sub (d) {
     if (d.txt.x + d.txt.y)
@@ -50,70 +52,6 @@ mp_doc.actions['delete_left']	= sub (d) {
     return d;
 };
 
-mp_doc.actions['indent_block'] = sub (d) {
-    d->store_undo();
-
-    if (d.txt.mark == NULL)
-        d->set_x(0)->insert_tab();
-    else {
-        local currentY = d.txt.y;
-        local startY   = d.txt.mark.by;
-        local endY     = d.txt.mark.ey;
-        local times    = endY - startY;
-	
-        d->unmark()->set_y(startY);
-
-        /* use to be while d.txt.y <= endY, but that entered an endless loop when
-            you were indenting a block including the very last line in the file */
-        while (times >= 0) {
-            d->set_x(0)->insert_tab()->move_down();
-		
-            times--;
-        }
-	
-        d->set_y(startY)->set_x(0)->mark();
-	
-        d->set_y(endY)->move_eol()->mark();
-	
-        d->set_y(currentY);
-    }
-
-    return d;
-};
-
-mp_doc.actions['unindent_block'] = sub(d) {
-    d->store_undo();
-
-    if (d.txt.mark == NULL) {
-        d->unindent_line();
-    }
-    else {
-        local currentY = d.txt.y;
-        local startY   = d.txt.mark.by;
-        local endY     = d.txt.mark.ey;
-        local times    = endY - startY;
-
-        d->unmark();
-
-        d->set_y(startY);
-
-        /* use to be while d.txt.y <= endY, but that entered an endless loop when
-            you were unindenting a block including the very last line in the file */
-        while (times >= 0) {
-            d->unindent_line()->move_down();
-		
-            times--;
-        }
-	
-        d->set_y(startY)->set_x(0)->mark();
-	
-        d->set_y(endY)->move_eol()->mark();
-	
-        d->set_y(currentY);
-    }
-
-    return d;
-};
 
 mp_doc.actions['undo'] = sub (d) { d->undo(); };
 mp_doc.actions['redo'] = sub (d) { d->redo(); };
@@ -289,6 +227,97 @@ mp.actdesc['tab_options']           = LL("Tab options...");
 mp.actdesc['toggle_insert']         = LL("Toggle insert/overwrite mode");
 
 /** code **/
+/**
+ * mp_doc.indent_block - Indent the currently selected block.
+ * @doc: the document
+ * @insert_tab: if set to 1 and there is no selection, it inserts a tab instead
+ *
+ * If a selection exists, this increases indentation for the selected lines.
+ * Else, it inserts a tabulation
+ */
+sub mp_doc.indent_block(doc, insert_tab) 
+{
+    if (doc.txt.mark == NULL) {
+        if (insert_tab)
+            doc->insert_tab();
+        else
+            doc->set_x(0)->insert_tab();
+    }
+    else {
+        local currentY = doc.txt.y;
+        local currentX = doc.txt.x;
+        local startY   = doc.txt.mark.by;
+        /* If the selection ends on a first column, don't indent the last line, it's not the user's intend */ 
+        local endY     = doc.txt.mark.ey - (doc.txt.mark.ex == 0);
+        local times    = endY - startY;
+        
+        doc->unmark()->set_y(startY);
+
+        /* use to be while d.txt.y <= endY, but that entered an endless loop when
+            you were indenting a block including the very last line in the file */
+        while (times >= 0) {
+            doc->set_x(0)->insert_tab()->move_down();
+		
+            times--;
+        }
+	
+        doc->set_y(startY)->set_x(0)->mark();
+	
+        doc->set_y(endY)->move_eol()->mark();
+	
+        doc->set_y(currentY);
+        if (!currentX) doc->set_x(0);
+    }
+
+    return doc;
+};
+
+/**
+ * mp_doc.unindent_block - Unindent the currently selected block.
+ * @doc: the document
+ * @insert_real_tab: if set to 1 and there is no selection, it inserts a real tab instead
+ *
+ * If a selection exists, this decreases indentation for the selected lines.
+ * Else, it inserts a real tabulation
+ */
+sub mp_doc.unindent_block(doc, insert_real_tab) 
+{
+    if (doc.txt.mark == NULL) {
+        if (insert_real_tab) 
+            doc->insert("\t");
+        else 
+            doc->unindent_line();
+    }
+    else {
+        local currentY = doc.txt.y;
+        local currentX = doc.txt.x;
+        local startY   = doc.txt.mark.by;
+        /* If the selection ends on a first column, don't indent the last line, it's not the user's intend */ 
+        local endY     = doc.txt.mark.ey - (doc.txt.mark.ex == 0);
+        local times    = endY - startY;
+
+        doc->unmark();
+
+        doc->set_y(startY);
+
+        /* use to be while d.txt.y <= endY, but that entered an endless loop when
+            you were unindenting a block including the very last line in the file */
+        while (times >= 0) {
+            doc->unindent_line()->move_down();
+		
+            times--;
+        }
+	
+        doc->set_y(startY)->set_x(0)->mark();
+	
+        doc->set_y(endY)->move_eol()->mark();
+	
+        doc->set_y(currentY);
+        if (!currentX) doc->set_x(0);
+    }
+
+    return doc;
+};
 
 /**
  * mp_doc.break_line - Breaks current line in two (inserts a newline).

--- a/mp_move.mpsl
+++ b/mp_move.mpsl
@@ -129,6 +129,7 @@ mp_doc.keycodes['mouse-wheel-up']       = "move_mouse_wheel_up";
 mp_doc.keycodes['mouse-wheel-down']     = "move_mouse_wheel_down";
 mp_doc.keycodes['alt-cursor-up']        = "scroll_up";
 mp_doc.keycodes['alt-cursor-down']      = "scroll_down";
+mp_doc.keycodes['ctrl-e']               = "document_list";
 
 /** action descriptions **/
 

--- a/mp_move.mpsl
+++ b/mp_move.mpsl
@@ -198,7 +198,7 @@ sub mp_doc.move(doc, func)
             doc->mark();
         }
         else {
-	    doc->unmark();
+            if (doc.txt.selecting_mode == NULL) doc->unmark();
             doc->func();
         }
     }

--- a/mp_move.mpsl
+++ b/mp_move.mpsl
@@ -196,8 +196,10 @@ sub mp_doc.move(doc, func)
             doc->func();
             doc->mark();
         }
-        else
+        else {
+	    doc->unmark();
             doc->func();
+        }
     }
 
     return doc;

--- a/mpv_curses.c
+++ b/mpv_curses.c
@@ -167,6 +167,30 @@ static mpdm_t nc_getkey(mpdm_t args, mpdm_t ctxt)
         return NULL;
     }
 
+    /* detect shift+left, shift+right, shift+up, shift+down, shift+pageup, shift+pagedown */
+    switch(f[0]) {
+    case 393:
+        mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
+        return MPDM_S(L"cursor-left");
+    case 402:
+        mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
+        return MPDM_S(L"cursor-right");
+    case 337:
+        mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
+        return MPDM_S(L"cursor-up");
+    case 336:
+        mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
+        return MPDM_S(L"cursor-down");
+    case 398:
+        mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
+        return MPDM_S(L"page-up");
+    case 396:
+        mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
+        return MPDM_S(L"page-down");
+    }
+
+
+    /* shift here stands for Alt or escape sequence code */
     if (shift) {
         switch (f[0]) {
         case L'0':

--- a/mpv_curses.c
+++ b/mpv_curses.c
@@ -169,28 +169,28 @@ static mpdm_t nc_getkey(mpdm_t args, mpdm_t ctxt)
 
     /* detect shift+left, shift+right, shift+up, shift+down, shift+pageup, shift+pagedown, shift+home, shift+end */
     switch(f[0]) {
-    case 393:
+    case KEY_SLEFT:
         mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
         return MPDM_S(L"cursor-left");
-    case 402:
+    case KEY_SRIGHT:
         mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
         return MPDM_S(L"cursor-right");
-    case 337:
+    case KEY_SR:
         mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
         return MPDM_S(L"cursor-up");
-    case 336:
+    case KEY_SF:
         mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
         return MPDM_S(L"cursor-down");
-    case 398:
+    case KEY_SPREVIOUS:
         mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
         return MPDM_S(L"page-up");
-    case 396:
+    case KEY_SNEXT:
         mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
         return MPDM_S(L"page-down");
-    case 386:
+    case KEY_SEND:
         mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
         return MPDM_S(L"end");
-    case 391:
+    case KEY_SHOME:
         mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
         return MPDM_S(L"home");
     }

--- a/mpv_curses.c
+++ b/mpv_curses.c
@@ -536,7 +536,7 @@ static mpdm_t nc_getkey(mpdm_t args, mpdm_t ctxt)
 
                 getmouse(&m);
 
-                if (m.bstate & BUTTON1_RELEASED)
+                if ((m.bstate & BUTTON1_RELEASED) && !(m.bstate & BUTTON1_CLICKED))
                 {
                     mpdm_hset_s(MP, L"mouse_to_x", MPDM_I(m.x));
                     mpdm_hset_s(MP, L"mouse_to_y", MPDM_I(m.y));
@@ -551,7 +551,7 @@ static mpdm_t nc_getkey(mpdm_t args, mpdm_t ctxt)
                 if (m.y == LINES - 1)
                     f = L"mouse-menu";
                 else
-                if (m.bstate & BUTTON1_PRESSED)
+                if (m.bstate & (BUTTON1_PRESSED | BUTTON1_CLICKED))
                     f = L"mouse-left-button";
                 else
                 if (m.bstate & BUTTON2_PRESSED)
@@ -836,9 +836,8 @@ static mpdm_t ncursesw_drv_startup(mpdm_t a)
             BUTTON3_PRESSED|
             BUTTON4_PRESSED|
             BUTTON1_RELEASED|
-            BUTTON2_RELEASED|
-            BUTTON3_RELEASED|
-            BUTTON4_RELEASED|
+            BUTTON1_CLICKED|
+            BUTTON1_DOUBLE_CLICKED|
             REPORT_MOUSE_POSITION,
             NULL);
     }

--- a/mpv_curses.c
+++ b/mpv_curses.c
@@ -187,10 +187,10 @@ static mpdm_t nc_getkey(mpdm_t args, mpdm_t ctxt)
     case 396:
         mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
         return MPDM_S(L"page-down");
-    case 360:
+    case 386:
         mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
         return MPDM_S(L"end");
-    case 262:
+    case 391:
         mpdm_hset_s(MP, L"shift_pressed", MPDM_I(1));
         return MPDM_S(L"home");
     }
@@ -536,6 +536,15 @@ static mpdm_t nc_getkey(mpdm_t args, mpdm_t ctxt)
 
                 getmouse(&m);
 
+                if (m.bstate & BUTTON1_RELEASED)
+                {
+                    mpdm_hset_s(MP, L"mouse_to_x", MPDM_I(m.x));
+                    mpdm_hset_s(MP, L"mouse_to_y", MPDM_I(m.y));
+
+                    f = L"mouse-drag";
+                    break;
+                }
+
                 mpdm_hset_s(MP, L"mouse_x", MPDM_I(m.x));
                 mpdm_hset_s(MP, L"mouse_y", MPDM_I(m.y));
 
@@ -826,6 +835,10 @@ static mpdm_t ncursesw_drv_startup(mpdm_t a)
             BUTTON2_PRESSED|
             BUTTON3_PRESSED|
             BUTTON4_PRESSED|
+            BUTTON1_RELEASED|
+            BUTTON2_RELEASED|
+            BUTTON3_RELEASED|
+            BUTTON4_RELEASED|
             REPORT_MOUSE_POSITION,
             NULL);
     }


### PR DESCRIPTION
Nano and emacs both have a cut line feature (`Ctrl+K` for nano) where it cuts the current line to the clipboard or the selection. It's a mix of selecting plus `Ctrl+X`, or only `Ctrl+X` if a selection exists already), except that you don't have to move your cursor while selecting (it's very useful in practice, since you only press one key instead of at least 4)

This pull request adds this feature, and a shortcut `Ctrl+E` to the new `document_list` feature I find very useful, but inaccessible in the menu.

It also includes shift based and mouse drag based selection with ncurses skin.

It also includes selection indenting and unindenting. 