### PR TITLE
Add local suspend feature via Ctrl+L

### DIFF
--- a/doc/mp_keycodes.txt
+++ b/doc/mp_keycodes.txt
@@ -70,6 +70,8 @@ Table with Minimum Profit's keycodes and their default assigned actions.
  +---------------------+------------------------+
  |              ctrl-q |                   exit |
  +---------------------+------------------------+
+ |              ctrl-l |                suspend |
+ +---------------------+------------------------+
  |              ctrl-r |                replace |
  +---------------------+------------------------+
  |              ctrl-s |                   save |

--- a/mp_core.mpsl
+++ b/mp_core.mpsl
@@ -190,7 +190,7 @@ global mp = {
                 '-', 'set_password',
                 '-', 'open_config_file', 'open_templates_file',
                 '-', 'sync',
-                '-', 'exit'
+                '-', 'suspend', 'exit'
             ]
         ],
         [

--- a/mp_file.mpsl
+++ b/mp_file.mpsl
@@ -88,6 +88,10 @@ mp.actions['exit']	= sub {
         mp_c.exit();
 };
 
+mp.actions['suspend'] = sub {
+    mp_drv.suspend();
+};
+
 mp.actions['open'] = sub (d, filename) {
     if (filename == NULL)
         filename = mp.openfile(L("File to open:"));
@@ -344,6 +348,7 @@ mp.actions['open_dropped_files'] = sub {
 mp.keycodes['ctrl-n']           = 'next';
 mp.keycodes['ctrl-o']           = 'open';
 mp.keycodes['ctrl-q']           = 'exit';
+mp.keycodes['ctrl-l']           = 'suspend';
 mp.keycodes['ctrl-w']           = 'close';
 mp.keycodes['dropped-files']    = 'open_dropped_files';
 mp.keycodes['close-window']     = 'exit';
@@ -360,6 +365,7 @@ mp.actdesc['next']               = LL("Next");
 mp.actdesc['prev']               = LL("Previous");
 mp.actdesc['open']               = LL("Open...");
 mp.actdesc['exit']               = LL("Exit");
+mp.actdesc['suspend']            = LL("Suspend");
 mp.actdesc['close']              = LL("Close");
 mp.actdesc['revert']             = LL("Revert");
 mp.actdesc['close_all']          = LL("Close all");

--- a/mpv_curses.c
+++ b/mpv_curses.c
@@ -732,6 +732,21 @@ static mpdm_t ncursesw_drv_shutdown(mpdm_t a, mpdm_t ctxt)
     return NULL;
 }
 
+static mpdm_t ncursesw_drv_suspend(mpdm_t a, mpdm_t ctxt)
+{
+    endwin();
+
+    printf("\nType 'fg' to return to Minimum Profit");
+    fflush(stdout);
+
+    /* Trigger suspending this process */
+    kill(getpid(), SIGSTOP);
+
+    /* Ok, we're back, let's refresh the screen */
+    wrefresh(cw);
+    
+    return NULL;
+}
 
 /** TUI **/
 
@@ -804,6 +819,7 @@ static void register_functions(void)
 
     mpdm_hset_s(drv, L"timer",      MPDM_X(ncursesw_drv_timer));
     mpdm_hset_s(drv, L"shutdown",   MPDM_X(ncursesw_drv_shutdown));
+    mpdm_hset_s(drv, L"suspend",    MPDM_X(ncursesw_drv_suspend));
 
     /* execute tui */
     tui = mpsl_eval(MPDM_LS(L"load('mp_tui.mpsl');"), NULL, NULL);


### PR DESCRIPTION
Like nano, pressing `Ctrl+L` suspend mp back into the starting shell, where you can execute shell command. When done, type `fg` to resume back to mp.