### PR TITLE
Add select word on double click

### DIFF
--- a/mp_move.mpsl
+++ b/mp_move.mpsl
@@ -78,6 +78,23 @@ mp_doc.actions['move_to_mouse_position'] = sub (d) {
     return d;
 };
 
+mp_doc.actions['select_word_under_cursor'] = sub(d) {
+    /* first, move the cursor on the clicked position */
+    d->move_to_coords_xy(mp.mouse_x - mp.xoffset, mp.mouse_y)->unmark();
+
+    /* split by words */
+    local l = d->split_line_by_words();
+    /* get current word */
+    local i = l[2];
+
+    /* select it based on its starting position and its size (don't use the 
+       next word position as it can be the last word on the line and we don't 
+       want to cross line boundaries like move_word_right does) */
+    d->set_x( l[1][i] )->mark()->set_x( l[1][i] + size(l[0][i]) )->mark();
+    
+    return d;
+};
+
 mp_doc.actions['move_mouse_wheel_up'] = sub (d) {
     d->move(sub (d) { d->move_up()->move_up()->move_up()->move_up();});
 };
@@ -127,6 +144,7 @@ mp_doc.keycodes['mouse-right-button']   = "move_to_mouse_position";
 mp_doc.keycodes['mouse-middle-button']  = "move_to_mouse_position";
 mp_doc.keycodes['mouse-wheel-up']       = "move_mouse_wheel_up";
 mp_doc.keycodes['mouse-wheel-down']     = "move_mouse_wheel_down";
+mp_doc.keycodes['mouse-left-dblclick']  = "select_word_under_cursor";
 mp_doc.keycodes['alt-cursor-up']        = "scroll_up";
 mp_doc.keycodes['alt-cursor-down']      = "scroll_down";
 mp_doc.keycodes['ctrl-e']               = "document_list";
@@ -146,6 +164,7 @@ mp.actdesc['move_eof']                  = LL("End of document");
 mp.actdesc['move_word_left']            = LL("Word left");
 mp.actdesc['move_word_right']           = LL("Word right");
 mp.actdesc['goto']                      = LL("Go to line...");
+mp.actdesc['select_word_under_cursor']  = LL("Select word under cursor");
 mp.actdesc['move_to_mouse_position']    = LL("Move cursor to mouse click");
 mp.actdesc['move_mouse_wheel_down']     = LL("Mouse wheel up");
 mp.actdesc['move_mouse_wheel_up']       = LL("Mouse wheel down");

--- a/mpv_curses.c
+++ b/mpv_curses.c
@@ -554,6 +554,9 @@ static mpdm_t nc_getkey(mpdm_t args, mpdm_t ctxt)
                 if (m.bstate & (BUTTON1_PRESSED | BUTTON1_CLICKED))
                     f = L"mouse-left-button";
                 else
+                if (m.bstate & BUTTON1_DOUBLE_CLICKED)
+                    f = L"mouse-left-dblclick";
+                else
                 if (m.bstate & BUTTON2_PRESSED)
                     f = L"mouse-middle-button";
                 else


### PR DESCRIPTION
As the title says, this is to mimic usual text editors. When you double click on a word, it's selected. Please notice that is is only implemented in ncurses mode, as I'm not using other platforms. I guess it should not be too hard to add to other platform, you need to intercept the platform's native double click event and emit an `mouse-left-dblclick` event, everything else will work out of the box.