### PR TITLE
Wrap on searching when reaching end of file.

### DIFF
--- a/mp_drv.mpsl
+++ b/mp_drv.mpsl
@@ -51,6 +51,7 @@ sub mp_drv.busy(onoff)          { return NULL; }
 /** driver wrappers **/
 
 sub mp.update_ui()			{ mp_drv.update_ui(); }
+sub mp.info(msg)			{ mp_drv.info(msg); }
 sub mp.alert(msg)			{ mp_drv.alert(msg); }
 sub mp.confirm(msg)			{ mp_drv.confirm(msg); }
 sub mp.openfile(prompt)		{ mp_drv.openfile(prompt); }

--- a/mp_search.mpsl
+++ b/mp_search.mpsl
@@ -60,13 +60,21 @@ mp_doc.actions['seek'] = sub (d) {
 };
 
 mp_doc.actions['seek_next'] = sub (d) {
-    d->long_op(mp_doc.search, NULL) || mp.alert(L("Text not found."));
+    if (!d->long_op(mp_doc.search, NULL)) {
+        d->move_bof();
+        d->long_op(mp_doc.search, NULL);
+        mp.info(L("Search wrapped."));
+    }
 
     return d;
 };
 
 mp_doc.actions['seek_prev'] = sub (d) {
-    d->long_op(mp_doc.search_back, NULL) || mp.alert(L("Text not found."));
+    if (!d->long_op(mp_doc.search_back, NULL)) { 
+        d->move_eof();
+        d->long_op(mp_doc.search_back, NULL);
+        mp.info(L("Search wrapped."));
+    }
 
     return d;
 };

--- a/mp_tui.mpsl
+++ b/mp_tui.mpsl
@@ -130,8 +130,9 @@ sub mp.tui.readline(prompt, history, default, flags)
 		}
 		else
 		if (k eq 'ctrl-v' && size(mp.clipboard)) {
-			r = mp.clipboard[0];
-			x = size(r);
+			r = splice(r, mp.clipboard[0], x, 0);
+			r = r[0];
+			x = x + size(mp.clipboard[0]);
 		}
 		else
 		if (k eq 'ctrl-k') {

--- a/mp_tui.mpsl
+++ b/mp_tui.mpsl
@@ -129,6 +129,11 @@ sub mp.tui.readline(prompt, history, default, flags)
 			r = '';
 		}
 		else
+		if (k eq 'ctrl-v' && size(mp.clipboard)) {
+			r = mp.clipboard[0];
+			x = size(r);
+		}
+		else
 		if (k eq 'ctrl-k') {
 			r = splice(r, NULL, x, -1);
 			r = r[0];
@@ -406,9 +411,16 @@ sub mp.tui.draw(doc)
     mp.tui.draw_scrollbar(doc);
 
 	/* draw the status line */
-	mp.tui.attr(mp.colors.normal.attr);
-	mp.tui.move(0, mp.window.ty - 1, 1);
-	mp.tui.addstr(mp.build_status_line());
+    if (mp.tui.info_line == NULL) {
+        mp.tui.attr(mp.colors.normal.attr);
+        mp.tui.move(0, mp.window.ty - 1, 1);
+        mp.tui.addstr(mp.build_status_line());
+    } else {
+        mp.tui.attr(mp.colors.menu.attr);
+        mp.tui.move(0, mp.window.ty - 1, 1);
+        mp.tui.addstr(mp.tui.info_line);
+        mp.tui.attr(mp.colors.normal.attr);
+    }
 
 	/* draw the 'menu' hint */
 	local t = "ctrl-a: " ~ L("Menu");
@@ -429,6 +441,11 @@ sub mp.tui.draw(doc)
 
 
 /** interface **/
+
+sub mp_drv.info(msg)
+{
+	mp.tui.info_line = msg;
+}
 
 sub mp_drv.alert(msg)
 {
@@ -732,7 +749,9 @@ sub mp_drv.main_loop()
 	while (!mp_c.exit_requested()) {
 		mp.tui.draw(mp.active());
 
-		mp.process_event(mp.tui.getkey());
+		local key = mp.tui.getkey();
+		mp.tui.info_line = NULL;
+		mp.process_event(key);
 	}
 }
 


### PR DESCRIPTION
Typically, this adds a mp.info() function that replace the status line with the info line until next event. Unlike alert, it does not interrupt event processing (or wait for Enter)
When searching for the next token and reaching end of file, instead of alerting "Text not found" and waiting for Enter key, it warps back to the beginning of the file, and search again from there.
It also display on the info line "Search wrapped" in the menu color.

Use it, you'll find it very intuitive (it acts like all other text editors).
I've also added the `Ctrl+V` feature in the prompt so you can paste what you have in the clipboard too.