### PR TITLE
Fix build with GTK 2.x

### DIFF
--- a/mpv_gtk.c
+++ b/mpv_gtk.c
@@ -2575,7 +2575,7 @@ static mpdm_t gtk_drv_startup(mpdm_t a, mpdm_t ctxt)
     gtk_box_pack_start(GTK_BOX(vbox), status, FALSE, FALSE, 0);
 
 #if CONFOPT_GTK == 2
-    gtk_misc_set_alignment(GTK_MISC(label), 0, .5);
+    gtk_misc_set_alignment(GTK_MISC(status), 0, .5);
 #endif
 #if CONFOPT_GTK == 3
     gtk_label_set_xalign(GTK_LABEL(status), 0.0);


### PR DESCRIPTION
```
mpv_gtk.c:2536:37: error: use of undeclared identifier 'label'; did you mean 'labs'?
    gtk_misc_set_alignment(GTK_MISC(label), 0, .5);
                                    ^~~~~
                                    labs
/usr/local/include/gtk-2.0/gtk/gtkmisc.h:41:61: note: expanded from macro 'GTK_MISC'
#define GTK_MISC(obj)                  (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_MISC, GtkMisc))
                                                                     ^
/usr/local/include/glib-2.0/gobject/gtype.h:482:80: note: expanded from macro 'G_TYPE_CHECK_INSTANCE_CAST'
#define G_TYPE_CHECK_INSTANCE_CAST(instance, g_type, c_type)    (_G_TYPE_CIC ((instance), (g_type), c_type))
                                                                               ^
/usr/local/include/glib-2.0/gobject/gtype.h:2224:57: note: expanded from macro '_G_TYPE_CIC'
    ((ct*) g_type_check_instance_cast ((GTypeInstance*) ip, gt))
                                                        ^
/usr/include/stdlib.h:100:7: note: 'labs' declared here
long     labs(long) __pure2;
         ^
1 error generated.
```