### PR TITLE
Fix many simple errors

### DIFF
--- a/mp_edit.mpsl
+++ b/mp_edit.mpsl
@@ -667,7 +667,13 @@ sub mp_doc.keypress(doc, key)
 /* inserts from a keystroke (with undo) */
 {
     if (size(key) == 1) {
-        doc->store_undo()->insert(key);
+        local t = time();
+        if ((t - doc.last_insert) > 1) {
+            /** Only store undo if sufficient time elapsed */
+            doc->store_undo();
+        } 
+        doc.last_insert = t; 
+        doc->insert(key);
     }
     else
     if (key != NULL) {

--- a/mp_edit.mpsl
+++ b/mp_edit.mpsl
@@ -243,7 +243,7 @@ sub mp_doc.indent_block(doc, insert_tab)
         local startY   = doc.txt.mark.by;
         /* If the selection ends on a first column, don't indent the last line, it's not the user's intend */ 
         local endY     = doc.txt.mark.ey - (doc.txt.mark.ex == 0);
-        local times    = endY - startY;
+        local times    = endY - startY + 1;
         
         doc->unmark()->set_y(startY);
 
@@ -285,7 +285,7 @@ sub mp_doc.unindent_block(doc, insert_real_tab)
         local startY   = doc.txt.mark.by;
         /* If the selection ends on a first column, don't indent the last line, it's not the user's intend */ 
         local endY     = doc.txt.mark.ey - (doc.txt.mark.ex == 0);
-        local times    = endY - startY;
+        local times    = endY - startY + 1;
 
         doc->unmark();
 

--- a/mp_edit.mpsl
+++ b/mp_edit.mpsl
@@ -487,7 +487,7 @@ sub mp_doc.delete_range(doc, bx, by, ex, ey, v)
         else {
             /* delete using vertical selection block */
             while (by <= ey) {
-                w = splice(txt.lines[by], NULL, bx, ex - bx);
+                w = splice(txt.lines[by], NULL, bx, ex - bx + 1);
                 txt.lines[by] = w;
                 by += 1;
             }

--- a/mp_edit.mpsl
+++ b/mp_edit.mpsl
@@ -506,6 +506,41 @@ sub mp_doc.insert_string(doc, str)
     local txt = doc.txt;
     local w;
 
+    if (txt.mark.vertical == 1) {
+        /* Need to perform vertical editing */
+        /* This insert the given string at all lines concerned by the mark itself (multiple time) */
+        /* Please notice that it does not remove the mark here, but modify it so it's only a single char wide */
+        
+        if (txt.mark.bx != txt.mark.ex) {
+            /* Need to delete all previous text in the mark first */
+            local old_mark = { bx: txt.mark.bx, by: txt.mark.by, ey: txt.mark.ey };
+            doc->delete_range(txt.mark.bx, txt.mark.by,
+                txt.mark.ex, txt.mark.ey, txt.mark.vertical);
+
+            /* Restore a zero column wide vertical mark */
+            txt.mark.vertical = 1;
+            txt.mark.bx = old_mark.bx; 
+            txt.mark.by = old_mark.by;
+            txt.mark.ex = old_mark.bx; 
+            txt.mark.ey = old_mark.ey;
+        }
+
+        /* Then insert the string at the given position */
+        local s = txt.mark.by;
+        while (s <= txt.mark.ey) {
+            w = splice(txt.lines[s], str, txt.mark.bx, mp.config.insert && size(str) || 0);
+            txt.lines[s] = w;
+
+            s += 1;
+        }
+        txt.mark.bx += size(str);
+        txt.mark.ex += size(str);
+        txt.x += size(str);
+
+        txt.mod += 1;
+
+        return doc;
+    }
     doc->delete_mark();
 
     /* splice and change */


### PR DESCRIPTION
First, I'm fixing of-by-one errors in vertical block selection deletion (which used to delete one column less than displayed), and in indentation of selections where the last line was not (un)indented.
I've also simplified the code to avoid storing a undo when typing fast (likely when you're pasting in a terminal). In that case, undo are saved each second instead (so a lot less undos to store and faster pasting and faster undoing too).

Finally, I've added support for multiline editing. Typically, you'll select vertical selection and start inserting, it'll reproduce your typing on all lines (like usual editors).
To explain better, let's say you have:
```
enum E
{
Value1,
Value2,
Value3,
};
```
And you set a vertical mark on the V column for all three values.
If you type `case `, you'll get:
```
enum E
{
case Value1,
case Value2,
case Value3,
};
```
Then, you can put a vertical selection on the last commas and type `: break;`, you'll get
```
enum E
{
case Value1: break;
case Value2: break;
case Value3: break;
};
```
Now it's trivial to make a `switch (arg)` modification to get a complete switch/case block.
Very easy and powerful. 

Please notice that it's not multicursor like in other editors (for ex: sublime) so you can't move the vertical selection on their own: if you press right, the selection will not move, only the cursor.