### PR TITLE
Fix a bug that's crashing mp when loading a session

### DIFF
--- a/mp_session.mpsl
+++ b/mp_session.mpsl
@@ -95,7 +95,7 @@ sub mp.load_session()
         if (stat(data[0]) != NULL) {
             doc = mp.open(data[0]);
 
-            doc->set_y(data[2])->set_x(data[1]);
+            doc->set_y(integer(data[2]))->set_x(integer(data[1]));
 
             /* if it has the 'a' flag, set as active */
             if (regex(data[3], '/a/'))


### PR DESCRIPTION
Simple fix that's solving mp from crashing.
Before this, while loading a session, scrolling on a file crashed mp because it was trying to reach inexistent line number in file.
The line number was computed wrongly by concatenating string instead of incrementing a number.
The fix make sure that the offset in the current document buffer are integers and not string so arithmetic operations are working. See bug #42 for details and the painful debug process.

Fix #42 
