### PR TITLE
Allow hint to also select directories in file selector

### DIFF
--- a/mp_tui.mpsl
+++ b/mp_tui.mpsl
@@ -352,6 +352,10 @@ sub mp.tui.list(prompt, data, pos, split_entry)
                 local entry = data[pos];
 
                 if (split_entry) {
+                    /* trim any trailing slash */
+                    if (entry[size(entry) - 1] == '/')
+                        entry = splice(entry, NULL, size(entry) - 1, 1);
+
                     local segment = split(entry, '/');
                     if (size(segment) > 0)
                         entry = segment[size(segment) - 1];


### PR DESCRIPTION
As the title says. Previously, while triggering the file selector, only files were considered while hinting. Now, all files and directories are used. 
Much more convenient.