### PR TITLE
Clang autocomplete

### DIFF
--- a/mp_core.mpsl
+++ b/mp_core.mpsl
@@ -145,6 +145,11 @@ global mp = {
         search: {
             text:   [ 'black', 'green' ],
             gui:    [ 0x000000, 0x00cc77 ]
+        },
+        suggest: {
+            text:   [ 'black', 'white' ],
+            gui:    [ 0x000000, 0x808080 ],
+            flags:  [ 'bright' ]
         }
     },
 
@@ -338,6 +343,8 @@ mp.colors.word3.gui         = [ 0xe0e0e0, 0x1b1b1b ];
 mp.colors.tag.gui           = [ 0x8888ff, 0x1b1b1b ];
 mp.colors.spell.gui         = [ 0xff8888, 0x1b1b1b ];
 mp.colors.search.gui        = [ 0x000000, 0x00cc77 ];
+mp.colors.search.gui        = [ 0x000000, 0x00cc77 ];
+mp.colors.suggest.gui       = [ 0x000000, 0x808080 ];
 
 /** MP base class **/
 

--- a/mp_crypt.mpsl
+++ b/mp_crypt.mpsl
@@ -193,8 +193,6 @@ sub mp.crypt_save(fd, lines, password, ver)
         fd->putchar(chr(crc->bitand(0x00ff)));
     }
 
-    close(fd);
-
     return nl;
 }
 

--- a/mp_file.mpsl
+++ b/mp_file.mpsl
@@ -569,8 +569,6 @@ sub mp.save_th(f, doc)
 
     doc.disk_op = 0;
 
-    close(f);
-
     return nl;
 }
 
@@ -602,7 +600,8 @@ sub mp_doc.save(doc)
             mp.crypt_save(f, doc.txt.lines, doc.password, doc.crypt_ver);
         else
             mp.save_th(f, doc);
-    
+
+        close(f);    
         doc.txt.mod = 0;
     
         /* set back the permissions and ownership, if available */

--- a/mp_tags.mpsl
+++ b/mp_tags.mpsl
@@ -65,17 +65,76 @@ mp_doc.actions['complete_symbol'] = sub(d) {
         mp.alert(L("No matching symbol found."));
 };
 
+/* completes the current word using clang */
+mp_doc.actions['complete_with_clang'] = sub(d) {
+    local w = d->get_word(), clang_options = "";
+    if (size(w) == 0)
+        return NULL;
+
+    d->busy(1);
+
+
+    /* the clang command to trigger is: 
+        clang -fsyntax-only -Xclang -code-completion-macros -Xclang -code-completion-patterns -Xclang -code-completion-brief-comments -Xclang -code-completion-at=file:line:col <clang-build-options> <file>
+       we use stdin here to avoid creating a temporary file 
+    */
+    local target = sprintf("clang -x%s -fsyntax-only -Xclang -code-completion-macros -Xclang -code-completion-brief-comments -Xclang -code-completion-at=-:%d:%d %s - 2>/dev/null", "c++", d.txt.y, d.txt.x - size(w), clang_options); 
+/*    mp.alert(sprintf(L("Executing: %s"), target)); */
+    local p, lines = [];
+    if ((p = popen2(target)) != NULL) {
+        /* write the document first */
+        mp.save_th(p[1], d);
+        pclose(p[1]);
+
+        foreach (l, p[0])
+            lines->push(mp.chomp(l));
+        
+        pclose(p[0]);
+        /* we only keep completions that start with the current word */
+        lines = lines->grep(regcomp('/^COMPLETION: ' + w + '/'))->map(sub(v) { split(v, ' : '); });
+    }
+    else {
+        d->busy(0);
+        mp.alert(sprintf(L("Error executing '%s'"), target));
+
+        return NULL;
+    }
+    if (size(lines) == 0) {
+        mp.message = {
+            timeout:    time() + 2,
+            string:     L("No completion found")
+        };
+
+        return NULL;
+    }
+
+    local list = [];
+    /* lines format is [[garbage, completion with arguments, <optional description>], ...] */
+    foreach(line, lines) {
+        if (line[1] != NULL) {
+            if (line[2] != NULL)
+                list->push(line[1] + "\t" + line[2]);
+            else list->push(line[1]);
+        }
+    }
+
+    d->busy(0);
+    d->complete(list);        
+};
+
 
 /** default key bindings **/
 
 mp_doc.keycodes['ctrl-t'] = "find_tag";
 mp_doc.keycodes['ctrl-u'] = "complete";
+mp_doc.keycodes['alt-u']  = "complete_with_clang";
 
 /** action descriptions **/
 
-mp.actdesc['find_tag']          = LL("Search tag...");
-mp.actdesc['complete']          = LL("Complete...");
-mp.actdesc['complete_symbol']   = LL("Symbol completion...");
+mp.actdesc['find_tag']            = LL("Search tag...");
+mp.actdesc['complete']            = LL("Complete...");
+mp.actdesc['complete_symbol']     = LL("Symbol completion...");
+mp.actdesc['complete_with_clang'] = LL("Completion with clang...");
 
 /** code **/
 
@@ -238,3 +297,4 @@ sub mp_doc.complete(d, list, label)
 
     return ret;
 }
+

--- a/mp_tags.mpsl
+++ b/mp_tags.mpsl
@@ -71,18 +71,29 @@ mp_doc.actions['complete_with_clang'] = sub(d) {
     if (size(w) == 0)
         return NULL;
 
-    d->busy(1);
+    local ext = "", extension = "";
+    ext = lc(d.name->regex("/\.[^.]+$/"));
+    if (ext == ".cpp") extension = "c++";
+    if (ext == ".c++") extension = "c++";
+    if (ext == ".cc")  extension = "c++";
+    if (ext == ".c")   extension = "c";
+    /* For headers we can't deduce if it's c++ or c, so let's guess it's C++ */
+    if (ext == ".h")   extension = "c++";
+    if (ext == ".hpp") extension = "c++";
+    if (ext == ".hh")  extension = "c++";
+    /* Clang only works for C/C++ */
+    if (extension == "") return NULL;
 
+    d->busy(1);
 
     /* the clang command to trigger is: 
         clang -fsyntax-only -Xclang -code-completion-macros -Xclang -code-completion-patterns -Xclang -code-completion-brief-comments -Xclang -code-completion-at=file:line:col <clang-build-options> <file>
        we use stdin here to avoid creating a temporary file 
     */
-    local target = sprintf("clang -x%s -fsyntax-only -Xclang -code-completion-macros -Xclang -code-completion-brief-comments -Xclang -code-completion-at=-:%d:%d %s - 2>/dev/null", "c++", d.txt.y, d.txt.x - size(w), clang_options); 
-/*    mp.alert(sprintf(L("Executing: %s"), target)); */
+    local target = sprintf("clang -x%s -fsyntax-only -Xclang -code-completion-macros -Xclang -code-completion-brief-comments -Xclang -code-completion-at=-:%d:%d %s - 2>/dev/null", extension, d.txt.y+1, d.txt.x - size(w)+1, clang_options); 
     local p, lines = [];
     if ((p = popen2(target)) != NULL) {
-        /* write the document first */
+        /* write the document first (close is done in the function) */
         mp.save_th(p[1], d);
         pclose(p[1]);
 
@@ -91,7 +102,7 @@ mp_doc.actions['complete_with_clang'] = sub(d) {
         
         pclose(p[0]);
         /* we only keep completions that start with the current word */
-        lines = lines->grep(regcomp('/^COMPLETION: ' + w + '/'))->map(sub(v) { split(v, ' : '); });
+        lines = lines->grep(regcomp('/^COMPLETION: ' + w + '/'))->map(sub(v) { split(v, ': '); });
     }
     else {
         d->busy(0);
@@ -112,12 +123,12 @@ mp_doc.actions['complete_with_clang'] = sub(d) {
     /* lines format is [[garbage, completion with arguments, <optional description>], ...] */
     foreach(line, lines) {
         if (line[1] != NULL) {
+            local completion = split(line[1], " ");
             if (line[2] != NULL)
-                list->push(line[1] + "\t" + line[2]);
-            else list->push(line[1]);
+                list->push(completion[0] + "\t" + line[2]);
+            else list->push(completion[0]);
         }
     }
-
     d->busy(0);
     d->complete(list);        
 };
@@ -268,7 +279,6 @@ sub mp_doc.complete(d, list, label)
                 /* more than one; ask user */
                 local r = mp.tui.list("Completion", l, 0, { 'y' => (d.txt.y - d.txt.vy) + 1, 'lines' => 5, 'x' => d.txt.x, 'color' => mp.colors.suggest.attr } );
 
-
                 if (r != NULL)
                     a = r[0];
             }
@@ -280,13 +290,15 @@ sub mp_doc.complete(d, list, label)
                 /* split line by words to take the offset of current word */
                 local r = d->split_line_by_words();
                 local offset = r[1][r[2]];
+                local ll = l[a]->split("\t");
+
 
                 /* substitute current word with newly selected word */
-                local w = splice(d.txt.lines[d.txt.y], l[a], offset, size(word));
+                local w = splice(d.txt.lines[d.txt.y], ll[0], offset, size(word));
 
                 /* change line and x cursor */
                 d.txt.lines[d.txt.y] = w;
-                d.txt.x = offset + size(l[a]);
+                d.txt.x = offset + size(ll[0]);
 
                 d.txt.mod += 1;
 

--- a/mp_tags.mpsl
+++ b/mp_tags.mpsl
@@ -15,7 +15,7 @@ mp.config.ctags_cmd = "ctags *";
 
 /** editor actions **/
 
-mp_doc.actions['find_tag']	= sub(d) {
+mp_doc.actions['find_tag'] = sub(d) {
     local tag = d->get_word();
 
     /* ask for it, taking the word under the cursor */
@@ -207,15 +207,8 @@ sub mp_doc.complete(d, list, label)
                 a = 0;
             else {
                 /* more than one; ask user */
-                local r = mp.form(
-                    [
-                        {
-                            label:  label || L("Select") + ':',
-                            type:   'list',
-                            list:   l
-                        }
-                    ]
-                );
+                local r = mp.tui.list("Completion", l, 0, { 'y' => (d.txt.y - d.txt.vy) + 1, 'lines' => 5, 'x' => d.txt.x, 'color' => mp.colors.suggest.attr } );
+
 
                 if (r != NULL)
                     a = r[0];

--- a/mp_tui.mpsl
+++ b/mp_tui.mpsl
@@ -168,7 +168,7 @@ sub mp.tui.readline(prompt, history, default, flags)
                 if (size(l)) {
                     ins(l, '../', 0);
 
-                    local p = mp.tui.list(prompt, l, 2, 1);
+                    local p = mp.tui.list(prompt, l, 2, { 'split_entry' => 1 });
 
                     if (p == NULL) {
                         r = NULL;
@@ -221,18 +221,60 @@ sub mp.tui.readline(prompt, history, default, flags)
 }
 
 
-sub mp.tui.list(prompt, data, pos, split_entry)
+sub mp.tui.list(prompt, data, pos, flags)
 /* select from a list */
 {
-    local vy, ty, hint, last_time;
+    local vy = 0, ty, hint, last_time, sy, sx = 0, lines = 0, sugc = mp.colors.normal.attr;
 
-    mp.tui.attr(mp.colors.menu.attr);
-    mp.tui.move(0, 0, 1);
-    mp.tui.addstr(prompt);
-    mp.tui.attr(mp.colors.normal.attr);
+    /* extract the top left position for the list */
+    if (flags != NULL && flags.y)
+        sy = flags.y;
+    else 
+        sy = 0;
 
-    vy = 0;
-    ty = mp.window.ty;
+    if (flags != NULL && flags.x) {
+        sx = flags.x;
+        /* make sure we have enough space to display a medium sized line */
+        if (sx + 64 > mp.window.tx) {
+            sx = 0;
+        }
+    }
+
+    /* compute the end position for the list */
+    if (flags != NULL && flags.lines) {
+        /* if it's doesn't fit the complete window, let's display it completely in the window */
+        if (flags.lines > mp.window.ty) {
+            sy = 0;
+            ty = mp.window.ty;
+        } else {
+            ty = flags.y + flags.lines + 1;
+
+            /* check that it fits the requirement, else move it above the start position */
+            if (ty > mp.window.ty) {
+                sy = flags.y - flags.lines - 2;
+                ty = flags.y - 1;
+            }
+        }
+    }
+    else 
+        ty = mp.window.ty;
+    
+    /* draw the prompt if it's provided */
+    if (prompt != NULL) {
+        mp.tui.attr(mp.colors.menu.attr);
+        mp.tui.move(sx, sy, 1);
+        mp.tui.addstr(prompt);
+        mp.tui.attr(mp.colors.normal.attr);
+        sy += 1;
+    }
+
+
+    if (flags != NULL && flags.color)
+        sugc = flags.color;
+
+
+
+    lines = ty - sy;
     last_time = 0;
     hint = "";
 
@@ -242,33 +284,33 @@ sub mp.tui.list(prompt, data, pos, split_entry)
     for (;;) {
         local k, n, cp;
 
-        /* limits for pos */
+        /* limits for pos (in data space) */
         if (pos < 0)
             pos = 0;
         if (pos >= size(data))
             pos = size(data) - 1;
 
-        /* limits for vy */
+        /* limits for vy (in data space) */
         if (pos < vy)
             vy = pos;
-        if (vy + ty <= pos)
-            vy = pos - ty + 1;
+        if ((vy + lines - 1) <= pos)
+            vy = pos - lines + 1;
 
         /* draw all the lines */
         n = 0;
-        while (n < ty) {
+        while (n < lines) {
             local l = data[n + vy];
 
             /* no more data? */
             if (l == NULL)
                 break;
 
-            if (n + vy == pos) {
+            if ((n + vy) == pos) {
                 cp = n;
                 mp.tui.attr(mp.colors.cursor.attr);
             }
             else
-                mp.tui.attr(mp.colors.normal.attr);
+                mp.tui.attr(sugc);
 
             /* split the line by tab in two columns */
             local ll = l->split("\t");
@@ -276,11 +318,11 @@ sub mp.tui.list(prompt, data, pos, split_entry)
             local l1 = ll[1] || '';
 
             /* draw the first part */
-            mp.tui.move(0, n + 1, 1);
+            mp.tui.move(sx, sy + n, 1);
             mp.tui.addstr(mp.trim(l0, mp.window.tx - count(l1)));
 
             /* draw the middle part */
-            mp.tui.addstr(map(mp.window.tx - count(l0) - count(l1), ' ')->join());
+            mp.tui.addstr(map(mp.window.tx - count(l0) - count(l1) - sx, ' ')->join());
 
             /* draw the second part */
             mp.tui.addstr(l1);
@@ -289,13 +331,14 @@ sub mp.tui.list(prompt, data, pos, split_entry)
         }
 
         /* clean the rest of lines */
-        mp.tui.attr(mp.colors.normal.attr);
-        while (n < ty) {
-            mp.tui.move(0, n + 1, 1);
+        mp.tui.attr(sugc);
+        while (n < lines) {
+            mp.tui.move(sx, sy + n, 1);
             n += 1;
         }
 
-        mp.tui.move(0, cp + 1);
+        mp.tui.move(sx, sy + cp);
+        mp.tui.attr(mp.colors.normal.attr);
         mp.tui.refresh();
 
         k = mp.tui.getkey();
@@ -314,10 +357,10 @@ sub mp.tui.list(prompt, data, pos, split_entry)
             pos += 1;
         else
         if (k == 'page-up')
-            pos -= ty;
+            pos -= (ty - sy);
         else
         if (k == 'page-down')
-            pos += ty;
+            pos += (ty - sy);
         else
         if (k == 'home')
             pos = 0;
@@ -351,7 +394,7 @@ sub mp.tui.list(prompt, data, pos, split_entry)
             while (pos < size(data) - 1) {
                 local entry = data[pos];
 
-                if (split_entry) {
+                if (flags != NULL && flags.split_entry) {
                     /* trim any trailing slash */
                     if (entry[size(entry) - 1] == '/')
                         entry = splice(entry, NULL, size(entry) - 1, 1);
@@ -556,7 +599,7 @@ sub mp_drv.form(widgets)
         }
         else
         if (w.type == 'list')
-            r1 = mp.tui.list(w.label, w.list, w.value, 0);
+            r1 = mp.tui.list(w.label, w.list, w.value);
 
         /* cancellation? */
         if (r1 == NULL) {

--- a/mpv_curses.c
+++ b/mpv_curses.c
@@ -541,7 +541,26 @@ static mpdm_t nc_tui_getkey(mpdm_t args, mpdm_t ctxt)
                 if (m.bstate & BUTTON4_PRESSED)
                     f = L"mouse-wheel-up";
                 else
+#if NCURSES_MOUSE_VERSION == 2
+                if (m.bstate & BUTTON5_PRESSED)
+                    f = L"mouse-wheel-down";
+                else
                     f = NULL;
+#else
+                {
+                    static MEVENT previous;
+                    /* with NCURSES_MOUSE_VERSION set to 1, there was no bit left in the state for wheel 
+                       down event and most distributions still ship with such version.
+                       In that case, mouse wheel down event is just an event that has not changed its position since
+                       last call. That's a bit hacky, but it seems to work */
+                    if (previous.x == m.x && previous.y == m.y)
+                        f = L"mouse-wheel-down";
+                    else
+                        f = NULL;
+        
+                    previous.x = m.x; previous.y = m.y;
+                }
+#endif
             }
             break;
 #endif /* NCURSES_MOUSE_VERSION */


### PR DESCRIPTION
This adds support for a better autocompletion for tags (now they are displayed in context) instead of a new document.
This also add support for using clang to autocomplete (so it understands much more of the code).

This requires merging my PR in mpdm for fixing a bug with `popen2/pclose` that's deadlocking mp when using such functions.



The output now looks like this:
![image](https://user-images.githubusercontent.com/3277165/65629060-02d33380-dfd3-11e9-9c68-5965af9ff213.png)

Triggering `clangautocomplete` is currently assigned to `alt-u` keystroke, but for a terminal, it's done by pressing `esc then u`. 

This also fix some nuisances in scrolling the screen with the mouse (sorry for not making 2 PR for this, forgot to create one when I did it first).

Please notice that setting clang options is still missing, since we must decide what would be the best way to do that (see #46)